### PR TITLE
Add a CI pipeline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  CI:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,25 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run tests
+      run: cargo test --verbose
+    - name: Clippy
+      run: |
+          rustup component add clippy
+          cargo clippy --all-targets

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,8 +115,9 @@ mod test {
     #[test]
     fn get_config_path_defaults_to_standard_config_directory() {
         let path = get_config_path(&None);
+        let check_path = PathBuf::from("/tmp").join("up").join("commands.toml");
         assert!(path.is_ok());
-        assert_eq!(path.unwrap(), "/tmp/up/commands.toml");
+        assert_eq!(path.unwrap(), check_path.to_str().unwrap());
     }
 
     #[test]

--- a/src/test/dirs.rs
+++ b/src/test/dirs.rs
@@ -2,5 +2,5 @@ use std::path::PathBuf;
 
 #[must_use]
 pub fn config_dir() -> Option<PathBuf> {
-    Some("/tmp/".into())
+    Some("/tmp".into())
 }


### PR DESCRIPTION
This project needs a CI/CD pipeline to publish binaries and make it easier to access them.

It uses a very similar pipeline as [alacritty](https://github.com/alacritty/alacritty).

As of right now, for simplicity's sake, releases will be done manually, but this may change in the future.